### PR TITLE
Dynamic eval metric

### DIFF
--- a/deeplite/profiler/formatter.py
+++ b/deeplite/profiler/formatter.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import logging
 
-from .metrics import Comparative, compare_status_values, Metric
+from .metrics import Comparative, compare_status_values, Metric, DynamicEvalMetric
 
 
 class _LoggerHolder:
@@ -208,7 +208,8 @@ def default_display_filter_function(status_dict):
 
     Remove 'Inference Time' as it is not a super relevant metric to display
     """
-    order = ('eval_metric', 'model_size', 'flops', 'total_params', 'memory_footprint', 'execution_time')
+    order = ('eval_metric',) + tuple(DynamicEvalMetric.REGISTRY)
+    order += ('model_size', 'flops', 'total_params', 'memory_footprint', 'execution_time')
     leftovers = tuple(set(status_dict.keys()) - set(('inference_time',) + order))
     order = order + leftovers
 

--- a/deeplite/profiler/metrics.py
+++ b/deeplite/profiler/metrics.py
@@ -218,19 +218,27 @@ class EvalMetric(Metric):
 
 
 class DynamicEvalMetric(Metric):
-    def __init__(self, name, unit_name='', comparative=Comparative.DIFF):
+    REGISTRY = []
+
+    def __init__(self, name, unit_name='', description=None, comparative=Comparative.DIFF):
         super().__init__()
         self._name = name
         self.unit_name = unit_name
+        if description and isinstance(description, str):
+            self._description = description
+        else:
+            self._description = "Computed performance of the model on the given data"
         self.comparative = comparative
+
+        if name not in self.REGISTRY:
+            self.REGISTRY.append(name)
 
     @property
     def NAME(self):
         return self._name
 
-    @staticmethod
-    def description():
-        return "Computed performance of the model on the given data"
+    def description(self):
+        return self._description
 
     def friendly_name(self):
         return "Eval: " + self.NAME

--- a/deeplite/profiler/metrics.py
+++ b/deeplite/profiler/metrics.py
@@ -233,7 +233,7 @@ class DynamicEvalMetric(Metric):
         return "Computed performance of the model on the given data"
 
     def friendly_name(self):
-        return "Evaluation Metric: " + self.NAME
+        return "Eval: " + self.NAME
 
     def get_units(self):
         return self.unit_name

--- a/deeplite/profiler/metrics.py
+++ b/deeplite/profiler/metrics.py
@@ -217,6 +217,31 @@ class EvalMetric(Metric):
         return self.comparative
 
 
+class DynamicEvalMetric(Metric):
+    def __init__(self, name, unit_name='', comparative=Comparative.DIFF):
+        super().__init__()
+        self._name = name
+        self.unit_name = unit_name
+        self.comparative = comparative
+
+    @property
+    def NAME(self):
+        return self._name
+
+    @staticmethod
+    def description():
+        return "Computed performance of the model on the given data"
+
+    def friendly_name(self):
+        return "Evaluation Metric: " + self.NAME
+
+    def get_units(self):
+        return self.unit_name
+
+    def get_comparative(self):
+        return self.comparative
+
+
 class InferenceTime(Metric):
     NAME = 'inference_time'
 

--- a/deeplite/profiler/profiler.py
+++ b/deeplite/profiler/profiler.py
@@ -437,10 +437,11 @@ class ComputeEvalMetric(ExternalProfilerFunction):
         split = split if split else self.default_split
         return super().pipe_kwargs_to_call(model, data_splits[split], kwargs)
 
-    def add_secondary_metric(self, key, unit_name=None, comparative=None):
+    def add_secondary_metric(self, key, unit_name=None, description=None, comparative=None):
         unit = self.unit_name if unit_name is None else unit_name
         comp = self.comparative if comparative is None else comparative
-        self.secondary_metrics.append(DynamicEvalMetric(name=key, unit_name=unit, comparative=comp))
+        new_metric = DynamicEvalMetric(key, unit_name=unit, description=description, comparative=comp)
+        self.secondary_metrics.append(new_metric)
 
     def __call__(self, *args, **kwargs):
         start = time.time()

--- a/deeplite/profiler/profiler.py
+++ b/deeplite/profiler/profiler.py
@@ -7,7 +7,7 @@ import time
 from .evaluate import EvaluationFunction
 from .formatter import getLogger, make_one_model_summary_str, make_two_models_summary_str, \
     default_display_filter_function
-from .metrics import EvalMetric, InferenceTime, Comparative
+from .metrics import EvalMetric, DynamicEvalMetric, InferenceTime, Comparative
 from .utils import cast_tuple
 
 logger = getLogger(__name__)
@@ -197,6 +197,7 @@ class Profiler(ABC):
         for sk in self.status_keys():
             if self.status_get(sk) is not None:
                 continue
+            # breakpoint()
             self.compute_status(sk, recompute=recompute, **kwargs)
 
         if print_mode:
@@ -412,6 +413,10 @@ class ComputeEvalMetric(ExternalProfilerFunction):
 
     This makes the additional assumption that an evaluation function is defined only on one split (
     or one data loader)
+
+    If the evaluation function returns a dict, this class can return secondary metrics from that dict.
+    For each key corresponding to a desired metric, call :meth:`add_secondary_metrics` with that key.
+    Optionally include the metric's unit_name and comparative if different from the eval_metric's
     """
 
     def __init__(self, func, key=None, default_split='test', unit_name='', comparative=Comparative.DIFF):
@@ -420,9 +425,12 @@ class ComputeEvalMetric(ExternalProfilerFunction):
         self.key = key
         self.unit_name = unit_name
         self.comparative = comparative
+        self.secondary_metrics = []
 
     def get_bounded_status_keys(self):
-        return EvalMetric(unit_name=self.unit_name, comparative=self.comparative), InferenceTime()
+        eval_metric = EvalMetric(unit_name=self.unit_name, comparative=self.comparative)
+        inf_metric = InferenceTime()
+        return (eval_metric, inf_metric, *self.secondary_metrics)
 
     def pipe_kwargs_to_call(self, model, data_splits, kwargs):
         kwargs = kwargs.copy()
@@ -430,12 +438,20 @@ class ComputeEvalMetric(ExternalProfilerFunction):
         split = split if split else self.default_split
         return super().pipe_kwargs_to_call(model, data_splits[split], kwargs)
 
-    # TODO support multiple secondary evaluation metrics
+    def add_secondary_metric(self, key, unit_name=None, comparative=None):
+        unit = self.unit_name if unit_name is None else unit_name
+        comp = self.comparative if comparative is None else comparative
+        self.secondary_metrics.append(DynamicEvalMetric(name=key, unit_name=unit, comparative=comp))
+
     def __call__(self, *args, **kwargs):
         start = time.time()
         rval = self._func(*args, **kwargs)
         inf_time = abs(time.time() - start)
 
         key = 'akey' if self.key is None else self.key
-        rval = EvaluationFunction.filter_call_rval(rval, return_dict=False, return_keys=key)
-        return {'eval_metric': rval, 'inference_time': inf_time}
+        rval1 = EvaluationFunction.filter_call_rval(rval, return_dict=False, return_keys=key)
+        metrics = {'eval_metric': rval1, 'inference_time': inf_time}
+        for metric in self.secondary_metrics:
+            metrics[metric.NAME] = EvaluationFunction.filter_call_rval(rval, return_dict=False,
+                                                                       return_keys=metric.NAME)
+        return metrics

--- a/deeplite/profiler/profiler.py
+++ b/deeplite/profiler/profiler.py
@@ -197,7 +197,6 @@ class Profiler(ABC):
         for sk in self.status_keys():
             if self.status_get(sk) is not None:
                 continue
-            # breakpoint()
             self.compute_status(sk, recompute=recompute, **kwargs)
 
         if print_mode:

--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,10 @@ with open('LICENSE') as f:
 TORCH_RANGE = "torch>=1.4, <=1.8.1"
 EXTRAS_REQUIRE = {
     'torch': [TORCH_RANGE, "ptflops==0.6.2"],
-    'tf-gpu': ["tensorflow-gpu==1.14; python_version <= '3.7.10'", "protobuf==3.20.*"],
-    'tf': ["tensorflow==1.14; python_version <= '3.7.10'", "protobuf==3.20.*"],
-    'all': [TORCH_RANGE, "ptflops==0.6.2", "tensorflow==1.14; python_version <= '3.7.10'", "protobuf==3.20.*"],
-    'all-gpu': [TORCH_RANGE, "ptflops==0.6.2", "tensorflow-gpu==1.14; python_version <= '3.7.10'", "protobuf==3.20.*"],
+    'tf-gpu': ["tensorflow-gpu==1.14; python_version <= '3.7.10'", "protobuf==3.19.*"],
+    'tf': ["tensorflow==1.14; python_version <= '3.7.10'", "protobuf==3.19.*"],
+    'all': [TORCH_RANGE, "ptflops==0.6.2", "tensorflow==1.14; python_version <= '3.7.10'", "protobuf==3.19.*"],
+    'all-gpu': [TORCH_RANGE, "ptflops==0.6.2", "tensorflow-gpu==1.14; python_version <= '3.7.10'", "protobuf==3.19.*"],
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,10 @@ with open('LICENSE') as f:
 TORCH_RANGE = "torch>=1.4, <=1.8.1"
 EXTRAS_REQUIRE = {
     'torch': [TORCH_RANGE, "ptflops==0.6.2"],
-    'tf-gpu': ["tensorflow-gpu==1.14; python_version <= '3.7.10'"],
-    'tf': ["tensorflow==1.14; python_version <= '3.7.10'"],
-    'all': [TORCH_RANGE, "ptflops==0.6.2", "tensorflow==1.14; python_version <= '3.7.10'"],
-    'all-gpu': [TORCH_RANGE, "ptflops==0.6.2", "tensorflow-gpu==1.14; python_version <= '3.7.10'"],
+    'tf-gpu': ["tensorflow-gpu==1.14; python_version <= '3.7.10'", "protobuf==3.20.*"],
+    'tf': ["tensorflow==1.14; python_version <= '3.7.10'", "protobuf==3.20.*"],
+    'all': [TORCH_RANGE, "ptflops==0.6.2", "tensorflow==1.14; python_version <= '3.7.10'", "protobuf==3.20.*"],
+    'all-gpu': [TORCH_RANGE, "ptflops==0.6.2", "tensorflow-gpu==1.14; python_version <= '3.7.10'", "protobuf==3.20.*"],
 }
 
 setup(
@@ -91,7 +91,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',        
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tests/tf_tests/functional/test_tf_profiler.py
+++ b/tests/tf_tests/functional/test_tf_profiler.py
@@ -1,6 +1,10 @@
 import pytest
 from pytest_mock import mocker
 from unittest import mock
+
+from deeplite.profiler.evaluate import EvaluationFunction
+from deeplite.profiler import ComputeEvalMetric
+from deeplite.profiler.metrics import Comparative
 from tests.tf_tests.functional import BaseFunctionalTest, TENSORFLOW_SUPPORTED, TENSORFLOW_AVAILABLE, get_profiler, make_model
 
 
@@ -38,3 +42,19 @@ class TestTFProfiler(BaseFunctionalTest):
         assert all(v1 == v2 for (k1, v1), (k2, v2) in zip(profiler.status_items(), profiler2.status_items())
                    if k1 not in ('layerwise_summary', 'inference_time', 'execution_time'))
 
+    def test_secondary_eval_override(self, *args):
+        profiler = get_profiler()
+        rval = {'acc': 1, 'b': 2, 'c': 4}
+        class DictReturnEval(EvaluationFunction):
+            def __call__(self, model, loader):
+                return rval
+
+        dummy_eval = DictReturnEval()
+        eval_profiler = ComputeEvalMetric(dummy_eval, 'acc', unit_name='%')
+        eval_profiler.add_secondary_metric('b')
+        eval_profiler.add_secondary_metric('c', 'ms', Comparative.DIV)
+        profiler.register_profiler_function(eval_profiler, override=True)
+        profiler.compute_status('eval_metric')
+        assert profiler.status_get('eval_metric') == rval['acc']
+        assert profiler.status_get('b') == rval['b']
+        assert profiler.status_get('c') == rval['c']

--- a/tests/tf_tests/functional/test_tf_profiler.py
+++ b/tests/tf_tests/functional/test_tf_profiler.py
@@ -52,9 +52,10 @@ class TestTFProfiler(BaseFunctionalTest):
         dummy_eval = DictReturnEval()
         eval_profiler = ComputeEvalMetric(dummy_eval, 'acc', unit_name='%')
         eval_profiler.add_secondary_metric('b')
-        eval_profiler.add_secondary_metric('c', 'ms', Comparative.DIV)
+        eval_profiler.add_secondary_metric('c', 'ms', 'milliseconds', Comparative.DIV)
         profiler.register_profiler_function(eval_profiler, override=True)
         profiler.compute_status('eval_metric')
+        profiler.display_status()
         assert profiler.status_get('eval_metric') == rval['acc']
         assert profiler.status_get('b') == rval['b']
         assert profiler.status_get('c') == rval['c']

--- a/tests/torch_tests/functional/test_torch_profiler.py
+++ b/tests/torch_tests/functional/test_torch_profiler.py
@@ -102,9 +102,10 @@ class TestTorchProfiler(BaseFunctionalTest):
         dummy_eval = DictReturnEval()
         eval_profiler = ComputeEvalMetric(dummy_eval, 'acc', unit_name='%')
         eval_profiler.add_secondary_metric('b')
-        eval_profiler.add_secondary_metric('c', 'ms', Comparative.DIV)
+        eval_profiler.add_secondary_metric('c', 'ms', 'milliseconds', Comparative.DIV)
         profiler.register_profiler_function(eval_profiler, override=True)
         profiler.compute_status('eval_metric')
+        profiler.display_status()
         assert profiler.status_get('eval_metric') == rval['acc']
         assert profiler.status_get('b') == rval['b']
         assert profiler.status_get('c') == rval['c']

--- a/tests/torch_tests/functional/test_torch_profiler.py
+++ b/tests/torch_tests/functional/test_torch_profiler.py
@@ -1,5 +1,9 @@
 import pytest
 from copy import deepcopy
+
+from deeplite.profiler.evaluate import EvaluationFunction
+from deeplite.profiler import ComputeEvalMetric
+from deeplite.profiler.metrics import Comparative
 from tests.torch_tests.functional import BaseFunctionalTest, TORCH_AVAILABLE, MODEL, get_profiler
 from unittest import mock
 
@@ -88,6 +92,19 @@ class TestTorchProfiler(BaseFunctionalTest):
         assert all(v1 == v2 for (k1, v1), (k2, v2) in zip(profiler.status_items(), profiler2.status_items())
                    if k1 not in ('layerwise_summary', 'inference_time', 'execution_time'))
 
+    def test_secondary_eval_override(self, *args):
+        profiler = get_profiler()
+        rval = {'acc': 1, 'b': 2, 'c': 4}
+        class DictReturnEval(EvaluationFunction):
+            def __call__(self, model, loader):
+                return rval
 
-
-
+        dummy_eval = DictReturnEval()
+        eval_profiler = ComputeEvalMetric(dummy_eval, 'acc', unit_name='%')
+        eval_profiler.add_secondary_metric('b')
+        eval_profiler.add_secondary_metric('c', 'ms', Comparative.DIV)
+        profiler.register_profiler_function(eval_profiler, override=True)
+        profiler.compute_status('eval_metric')
+        assert profiler.status_get('eval_metric') == rval['acc']
+        assert profiler.status_get('b') == rval['b']
+        assert profiler.status_get('c') == rval['c']


### PR DESCRIPTION
New profiler metric which allows the profiler to print secondary eval metrics in the table. 
Interface is through the `ComputeEvalMetric.add_secondary_metric` method. The secondary metric is identified by its key in the dict returned by the eval function, so this metric can only work with an eval function which returns a dict.

Example usage: 
```
def my_eval_func(model, data_splits):
   return {'accuracy': 50, 'precision': 0.5, 'recall': 0.5}

# Setup eval metric profiler function
eval_metric = ComputeEvalMetric(my_eval_func, key='accuracy')
eval_metric.add_secondary_metric(key='precision', unit_name='')
eval_metric.add_secondary_metric(key='recall', unit_name='')

# pass profiler function to Neutrino
opt_model = Neutrino(..., custom_profiler_functions=eval_metric).run()
```

Example output:
```
+---------------------------------------------------------------+
|                       Deeplite Profiler                       |
+-----------------------------------------+---------------------+
|            Param Name (Reference Model) |                Value|
|                   Backend: TorchBackend |                     |
+-----------------------------------------+---------------------+
|                   Evaluation Metric (%) |               1.0000|
|                      Eval: precision () |               0.5000|
|                         Eval: recall () |               0.5000|
|                         Model Size (MB) |              42.8014|
|     Computational Complexity (GigaMACs) |               0.5567|
|             Total Parameters (Millions) |              11.2201|
|                   Memory Footprint (MB) |              51.4272|
|                     Execution Time (ms) |               0.0762|
+-----------------------------------------+---------------------+
```