### PR TITLE
Dynamic keys and display refactor

### DIFF
--- a/deeplite/profiler/formatter.py
+++ b/deeplite/profiler/formatter.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from collections import OrderedDict
 import logging
 
@@ -88,159 +89,224 @@ def parse_metric(metric):
     return text, value, units, comparative, description
 
 
-def make_one_model_summary_str(status_dict, short_print=True, description_str='', summary_str='\n'):
-    line_length, col1_length, col2_length = 63, 40, 20
-    summary_str += "+" + "-" * line_length + "+" + "\n"
-    line_new = "|{:^{line_length}}|".format("Deeplite Profiler", line_length=line_length)
-    summary_str += line_new + "\n"
-    summary_str += "+" + "-" * (col1_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
-    line_new = "|{:>{col1_length}} | {:>{col2_length}}|".format("Param Name (" + status_dict['name'] + ")",
-                                                                "Value", col1_length=col1_length,
-                                                                col2_length=col2_length)
-    summary_str += line_new + "\n"
-    line_new = "|{:>{col1_length}} | {:>{col2_length}}|".format("Backend: " + status_dict['backend'], "",
-                                                                col1_length=col1_length,
-                                                                col2_length=col2_length)
-    summary_str += line_new + "\n"
-    summary_str += "+" + "-" * (col1_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
+class Display:
+    def __init__(self, logger, order=None, include_leftovers=True, exclude=None):
+        self.logger = logger
+        self.order = order
+        self.include_leftovers = include_leftovers
+        self.exclude = exclude
 
-    for status in status_dict.values():
-        if not isinstance(status, Metric):
-            continue
-        text, value, units, _, desc = parse_metric(status)
-        print_str = text + ' (' + units + ')'
-        line_new = "|{0:>{col1_length}} | {1:>{col2_length}.4f}|".format(print_str, value,
-                                                                         col1_length=col1_length,
-                                                                         col2_length=col2_length)
-        summary_str += line_new + "\n"
-        description_str += '* ' + text + ': ' + desc + "\n"
-    summary_str += "+" + "-" * (col1_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
+    def display_status(self, profiler, other=None, print_mode='debug', short_print=True):
+        """
+        Beautiful user-friendly display of either one or two dictionaries of profiler status
 
-    if not short_print:
-        # Creating footnote
-        summary_str += "Note: " + "\n"
-        summary_str += description_str
-        summary_str += "+" + "-" * line_length + "+"
+        :param other: An optional second status message to compare, defaults to None
+        :type other: dictionary, optional
+        :param print_mode: Logger print mode, defaults to 'debug'
+        :type print_mode: str, optional
+        :param short_print: If to display a short version of the profiled output or a long detailed version,
+            defaults to True
+        :type short_print: bool, optional
+        """
+        # NOTE: force pop layerwise summary and display in debug mode as it is quite long regardless
+        # of the display filter function.
+        assert isinstance(print_mode, str) and hasattr(self.logger, print_mode.lower()), \
+            "'print_mode' needs to be a logger level"
 
-    return summary_str
+        display_filter_func = self.make_display_filter_function(profiler, self.order, self.include_leftovers, self.exclude)
+        status_dict = profiler.status_to_dict(to_value=False)
+        layerwise_summary_1 = status_dict.pop('layerwise_summary', None)
+        status_dict = display_filter_func(status_dict)
+        status_dict['backend'] = profiler.backend
+        status_dict['name'] = profiler.name
+
+        if other is not None:
+            other_status_dict = other.status_to_dict(to_value=False)
+            layerwise_summary_2 = other_status_dict.pop('layerwise_summary', None)
+            other_status_dict = display_filter_func(other_status_dict)
+            other_status_dict['backend'] = other.backend
+            other_status_dict['name'] = other.name
+            summary_str = self.make_two_models_summary_str(status_dict, other_status_dict, short_print=short_print)
+        else:
+            layerwise_summary_2 = None
+            summary_str = self.make_one_model_summary_str(status_dict, short_print=short_print)
+
+        if not short_print:
+            if layerwise_summary_1:
+                self.logger.debug(layerwise_summary_1.value)
+            if layerwise_summary_2:
+                self.logger.debug(layerwise_summary_2.value)
+        getattr(self.logger, print_mode.lower())(summary_str)
+
+    @abstractmethod
+    def make_display_filter_function(self, profiler, order=None, include_leftovers=True, exclude=None):
+        """
+        Create the display function. The default order displayed on the table is like this:
+                - Evaluation Metric
+                - Sub evaluation Metric (if any)
+                - Model Size
+                - Computational Complexity
+                - Number of Parameters
+                - Memory Footprint
+                - Execution Time
+                - Inference Time
+                - Any other custom Metric
+
+        :param order: Order of status keys to display, None is for the order defined in above docstring, defaults to None
+        :type order: Optional[Iterable[str]]
+        :param include_leftovers: Append all other status keys unspecified by the order at the end, defaults to True
+        :type include_leftovers: Bool
+        :param exclude: Sets of status keys to not display, defaults to None
+        :type exclude: Optional[Set[str]]
+        :return: filter function `callable`
+        """
+
+    @abstractmethod
+    def make_one_model_summary_str(self, status_dict, short_print=True, description_str='', summary_str='\n'):
+        """
+        Return multiline string to display data from status_dict
+        """
+
+    @abstractmethod
+    def make_two_models_summary_str(self, status_dict, status_dict_2, short_print=True, description_str='',
+                                    summary_str='\n'):
+        """
+        Return multiline string to display data from two status_dicts
+        """
 
 
-def make_two_models_summary_str(status_dict, status_dict_2, short_print=True, description_str='',
-                                summary_str='\n'):
-    line_length, col0_length, col1_length, col2_length, col3_length = 122, 40, 25, 25, 25
-    summary_str += "+" + "-" * line_length + "+" + "\n"
-    line_new = "|{:^{line_length}}|".format("Deeplite Profiler", line_length=line_length)
-    summary_str += line_new + "\n"
-    summary_str += "+" + "-" * (col0_length + 1) + "+" + "-" * (col1_length + 1) + "+" + "-" * (
-            col2_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
-    line_new = "|{:>{col0_length}} | {:>{col1_length}}| {:>{col2_length}}| {:>{col3_length}}|".format(
-        "Param Name", "Enhancement", "Value (" + status_dict['name'] + ")",
-                                     "Value (" + status_dict_2['name'] + ")", col0_length=col0_length,
-        col1_length=col1_length,
-        col2_length=col2_length, col3_length=col3_length)
-    summary_str += line_new + "\n"
-    line_new = "|{:>{col0_length}} | {:>{col1_length}}| {:>{col2_length}}| {:>{col3_length}}|".format(
-        "", "", "Backend: " + status_dict['backend'], "Backend: " + status_dict_2['backend'],
-        col0_length=col0_length, col1_length=col1_length, col2_length=col2_length, col3_length=col3_length)
-    summary_str += line_new + "\n"
-    summary_str += "+" + "-" * (col0_length + 1) + "+" + "-" * (col1_length + 1) + "+" + "-" * (
-            col2_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
-
-    for sk, sv in status_dict.items():
-        if sk in status_dict_2 and isinstance(sv, Metric):
-            sv2 = status_dict_2[sk]
-            text, value_1, units_1, comp, desc = parse_metric(sv)
-            _, value_2, units_2, _, _ = parse_metric(sv2)
-
-            if comp is None:
-                comp = Comparative.NONE
-
-            if units_1 != "" and units_2 != "" and units_1 != units_2:
-                # TODO fix when units are not the same
-                val = "<Unsupported units>"
+class DefaultDisplay(Display):
+    def make_display_filter_function(self, profiler, order=None, include_leftovers=True, exclude=None):
+        eval_pfr = profiler.get_eval_pfr()
+        secondary_metrics = tuple([m.NAME for m in eval_pfr.function.secondary_metrics])
+        print(secondary_metrics)
+        def order_iter():
+            if order is None:
+                _order = ('eval_metric',) + secondary_metrics
+                _order += ('model_size', 'flops', 'total_params', 'memory_footprint', 'execution_time', 'inference_time')
             else:
-                try:
-                    # this should raise a ValueError if the str is not correct
-                    if isinstance(comp, str):
-                        comp = Comparative(comp)
-                    rval = compare_status_values(comp, value_1, value_2)
-                except ZeroDivisionError:
-                    val = "INF"
-                except ValueError:
-                    val = "<Error Comparing>"
-                else:
-                    if rval is None:
-                        val = '---'
-                    else:
-                        format_str = "{:>.2f}"
-                        if comp is not Comparative.DIFF:
-                            format_str += "x"
-                        val = format_str.format(rval)
+                _order = order
+            for o in _order:
+                yield o
+        exclude = cast_tuple(exclude)
 
-            print_str = text + ' (' + units_1 + ')'
-            line_new = "|{:>{col0_length}} | {:>{col1_length}}| {:>{col2_length}.4f}| {:>{col3_length}.4f}|".format(
-                print_str, val, value_1, value_2,
-                col0_length=col0_length, col1_length=col1_length, col2_length=col2_length,
-                col3_length=col3_length)
+        def display_filter_function(status_dict):
+            new_status_dict = OrderedDict()
+
+            for k in order_iter():
+                if k not in exclude and k in status_dict:
+                    new_status_dict[k] = status_dict[k]
+
+            if include_leftovers:
+                for k in set(status_dict) - (set(new_status_dict) | set(exclude)):
+                    new_status_dict[k] = status_dict[k]
+
+            return new_status_dict
+
+        return display_filter_function
+
+    def make_one_model_summary_str(self, status_dict, short_print=True, description_str='', summary_str='\n'):
+        line_length, col1_length, col2_length = 63, 40, 20
+        summary_str += "+" + "-" * line_length + "+" + "\n"
+        line_new = "|{:^{line_length}}|".format("Deeplite Profiler", line_length=line_length)
+        summary_str += line_new + "\n"
+        summary_str += "+" + "-" * (col1_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
+        line_new = "|{:>{col1_length}} | {:>{col2_length}}|".format("Param Name (" + status_dict['name'] + ")",
+                                                                    "Value", col1_length=col1_length,
+                                                                    col2_length=col2_length)
+        summary_str += line_new + "\n"
+        line_new = "|{:>{col1_length}} | {:>{col2_length}}|".format("Backend: " + status_dict['backend'], "",
+                                                                    col1_length=col1_length,
+                                                                    col2_length=col2_length)
+        summary_str += line_new + "\n"
+        summary_str += "+" + "-" * (col1_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
+
+        for status in status_dict.values():
+            if not isinstance(status, Metric):
+                continue
+            text, value, units, _, desc = parse_metric(status)
+            print_str = text + ' (' + units + ')'
+            line_new = "|{0:>{col1_length}} | {1:>{col2_length}.4f}|".format(print_str, value,
+                                                                            col1_length=col1_length,
+                                                                            col2_length=col2_length)
             summary_str += line_new + "\n"
             description_str += '* ' + text + ': ' + desc + "\n"
-    summary_str += "+" + "-" * (col0_length + 1) + "+" + "-" * (col1_length + 1) + "+" + "-" * (
-            col2_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
+        summary_str += "+" + "-" * (col1_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
 
-    # Creating footnote
-    if not short_print:
-        summary_str += "Note: " + "\n"
-        summary_str += description_str
-        summary_str += "+" + "-" * line_length + "+"
+        if not short_print:
+            # Creating footnote
+            summary_str += "Note: " + "\n"
+            summary_str += description_str
+            summary_str += "+" + "-" * line_length + "+"
 
-    return summary_str
+        return summary_str
 
+    def make_two_models_summary_str(self, status_dict, status_dict_2, short_print=True, description_str='',
+                                    summary_str='\n'):
+        line_length, col0_length, col1_length, col2_length, col3_length = 122, 40, 25, 25, 25
+        summary_str += "+" + "-" * line_length + "+" + "\n"
+        line_new = "|{:^{line_length}}|".format("Deeplite Profiler", line_length=line_length)
+        summary_str += line_new + "\n"
+        summary_str += "+" + "-" * (col0_length + 1) + "+" + "-" * (col1_length + 1) + "+" + "-" * (
+                col2_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
+        line_new = "|{:>{col0_length}} | {:>{col1_length}}| {:>{col2_length}}| {:>{col3_length}}|".format(
+            "Param Name", "Enhancement", "Value (" + status_dict['name'] + ")",
+                                        "Value (" + status_dict_2['name'] + ")", col0_length=col0_length,
+            col1_length=col1_length,
+            col2_length=col2_length, col3_length=col3_length)
+        summary_str += line_new + "\n"
+        line_new = "|{:>{col0_length}} | {:>{col1_length}}| {:>{col2_length}}| {:>{col3_length}}|".format(
+            "", "", "Backend: " + status_dict['backend'], "Backend: " + status_dict_2['backend'],
+            col0_length=col0_length, col1_length=col1_length, col2_length=col2_length, col3_length=col3_length)
+        summary_str += line_new + "\n"
+        summary_str += "+" + "-" * (col0_length + 1) + "+" + "-" * (col1_length + 1) + "+" + "-" * (
+                col2_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
 
-def make_display_filter_function(order=None, include_leftovers=True, exclude=None):
-    """
-    Create the display function. The default order displayed on the table is like this:
-            - Evaluation Metric
-            - Sub evaluation Metric (if any)
-            - Model Size
-            - Computational Complexity
-            - Number of Parameters
-            - Memory Footprint
-            - Execution Time
-            - Inference Time
-            - Any other custom Metric
+        for sk, sv in status_dict.items():
+            if sk in status_dict_2 and isinstance(sv, Metric):
+                sv2 = status_dict_2[sk]
+                text, value_1, units_1, comp, desc = parse_metric(sv)
+                _, value_2, units_2, _, _ = parse_metric(sv2)
 
-    :param order: Order of status keys to display, None is for the order defined in above docstring, defaults to None
-    :type order: Optional[Iterable[str]]
-    :param include_leftovers: Append all other status keys unspecified by the order at the end, defaults to True
-    :type include_leftovers: Bool
-    :param exclude: Sets of status keys to not display, defaults to None
-    :type exclude: Optional[Set[str]]
-    :return: filter function `callable`
-    """
-    def order_iter():
-        if order is None:
-            _order = ('eval_metric',) + tuple(DynamicEvalMetric.REGISTRY)
-            _order += ('model_size', 'flops', 'total_params', 'memory_footprint', 'execution_time', 'inference_time')
-        else:
-            _order = order
-        for o in _order:
-            yield o
-    exclude = cast_tuple(exclude)
+                if comp is None:
+                    comp = Comparative.NONE
 
-    def display_filter_function(status_dict):
-        new_status_dict = OrderedDict()
+                if units_1 != "" and units_2 != "" and units_1 != units_2:
+                    # TODO fix when units are not the same
+                    val = "<Unsupported units>"
+                else:
+                    try:
+                        # this should raise a ValueError if the str is not correct
+                        if isinstance(comp, str):
+                            comp = Comparative(comp)
+                        rval = compare_status_values(comp, value_1, value_2)
+                    except ZeroDivisionError:
+                        val = "INF"
+                    except ValueError:
+                        val = "<Error Comparing>"
+                    else:
+                        if rval is None:
+                            val = '---'
+                        else:
+                            format_str = "{:>.2f}"
+                            if comp is not Comparative.DIFF:
+                                format_str += "x"
+                            val = format_str.format(rval)
 
-        for k in order_iter():
-            if k not in exclude and k in status_dict:
-                new_status_dict[k] = status_dict[k]
+                print_str = text + ' (' + units_1 + ')'
+                line_new = "|{:>{col0_length}} | {:>{col1_length}}| {:>{col2_length}.4f}| {:>{col3_length}.4f}|".format(
+                    print_str, val, value_1, value_2,
+                    col0_length=col0_length, col1_length=col1_length, col2_length=col2_length,
+                    col3_length=col3_length)
+                summary_str += line_new + "\n"
+                description_str += '* ' + text + ': ' + desc + "\n"
+        summary_str += "+" + "-" * (col0_length + 1) + "+" + "-" * (col1_length + 1) + "+" + "-" * (
+                col2_length + 1) + "+" + "-" * (col2_length + 1) + "+" + "\n"
 
-        if include_leftovers:
-            for k in set(status_dict) - (set(new_status_dict) | set(exclude)):
-                new_status_dict[k] = status_dict[k]
+        # Creating footnote
+        if not short_print:
+            summary_str += "Note: " + "\n"
+            summary_str += description_str
+            summary_str += "+" + "-" * line_length + "+"
 
-        return new_status_dict
-
-    return display_filter_function
-
-
-default_display_filter_function = make_display_filter_function()
+        return summary_str

--- a/deeplite/profiler/formatter.py
+++ b/deeplite/profiler/formatter.py
@@ -178,8 +178,9 @@ class Display:
 class DefaultDisplay(Display):
     def make_display_filter_function(self, profiler, order=None, include_leftovers=True, exclude=None):
         eval_pfr = profiler.get_eval_pfr()
-        secondary_metrics = tuple([m.NAME for m in eval_pfr.function.secondary_metrics])
-        print(secondary_metrics)
+        secondary_metrics = ()
+        if eval_pfr:
+            secondary_metrics += tuple([m.NAME for m in eval_pfr.function.secondary_metrics])
         def order_iter():
             if order is None:
                 _order = ('eval_metric',) + secondary_metrics

--- a/deeplite/profiler/metrics.py
+++ b/deeplite/profiler/metrics.py
@@ -218,8 +218,6 @@ class EvalMetric(Metric):
 
 
 class DynamicEvalMetric(Metric):
-    REGISTRY = []
-
     def __init__(self, name, unit_name='', description=None, comparative=Comparative.DIFF):
         super().__init__()
         self._name = name
@@ -229,9 +227,6 @@ class DynamicEvalMetric(Metric):
         else:
             self._description = "Computed performance of the model on the given data"
         self.comparative = comparative
-
-        if name not in self.REGISTRY:
-            self.REGISTRY.append(name)
 
     @property
     def NAME(self):

--- a/deeplite/profiler/profiler.py
+++ b/deeplite/profiler/profiler.py
@@ -278,6 +278,9 @@ class Profiler(ABC):
         :param key: key of the metric in the dictionary returned by the EvaluationFunction
         """
         eval_pfr = self._get_eval_pfr()
+        if not eval_pfr:
+            raise ValueError(("Cannot add secondary metrics without evaluation function. \n"
+                              "Register an evaluation function before adding secondary metrics"))
         eval_pfr.function.add_secondary_metric(key, unit_name, description, comparative)
         secondary_eval_metric = eval_pfr.function.secondary_metrics[-1]
         self._register_status_key(secondary_eval_metric, eval_pfr.function, eval_pfr.overriding)

--- a/deeplite/profiler/profiler.py
+++ b/deeplite/profiler/profiler.py
@@ -253,8 +253,6 @@ class Profiler(ABC):
         """
         # NOTE: force pop layerwise summary and display in debug mode as it is quite long regardless
         # of the display filter function.
-        assert isinstance(print_mode, str) and hasattr(logger, print_mode.lower()), \
-            "'print_mode' needs to be a logger level"
         self.display.display_status(self, other, print_mode, short_print)
 
     def clone(self, model=None, data_splits=None, retain_status=False):

--- a/deeplite/profiler/profiler.py
+++ b/deeplite/profiler/profiler.py
@@ -5,8 +5,7 @@ from inspect import signature, Parameter
 import time
 
 from .evaluate import EvaluationFunction
-from .formatter import getLogger, \
-    DefaultDisplay
+from .formatter import getLogger, DefaultDisplay
 from .metrics import EvalMetric, DynamicEvalMetric, InferenceTime, Comparative
 from .utils import cast_tuple
 
@@ -16,6 +15,7 @@ _ProfilerFunctionRegister = namedtuple("_ProfilerFunctionRegister", ('function',
                                        module=__name__)
 
 default_display = DefaultDisplay(logger)
+
 
 class Profiler(ABC):
     """

--- a/tests/profiler_tests/unit/test_profiler.py
+++ b/tests/profiler_tests/unit/test_profiler.py
@@ -69,8 +69,8 @@ class TestProfiler(BaseUnitTest):
         profiler.display_status_filter_func = make_display_filter_function(exclude='c')
         compute_eval = ComputeEvalMetric(evaluate, key='a', default_split='train')
         compute_eval.add_secondary_metric('b')
-        compute_eval.add_secondary_metric('c')
         profiler.register_profiler_function(compute_eval)
+        profiler.add_secondary_eval_metric('c')
 
         status = profiler.compute_network_status()
         assert 'inference_time' in status

--- a/tests/profiler_tests/unit/test_profiler.py
+++ b/tests/profiler_tests/unit/test_profiler.py
@@ -66,6 +66,8 @@ class TestProfiler(BaseUnitTest):
             return {'a': 10, 'b': 20, 'c': 30, 'd': 40}
 
         profiler = get_profiler()
+        with pytest.raises(ValueError):
+            profiler.add_secondary_eval_metric('c')
         profiler.display.exclude = 'c'
         compute_eval = ComputeEvalMetric(evaluate, key='a', default_split='train')
         compute_eval.add_secondary_metric('b')

--- a/tests/profiler_tests/unit/test_profiler.py
+++ b/tests/profiler_tests/unit/test_profiler.py
@@ -2,7 +2,7 @@ import pytest
 from tests.profiler_tests.unit import BaseUnitTest
 from unittest import mock
 
-from deeplite.profiler.formatter import getLogger, setLogger, make_display_filter_function
+from deeplite.profiler.formatter import getLogger, setLogger
 from deeplite.profiler.profiler import Profiler, ProfilerFunction, ExternalProfilerFunction, ComputeEvalMetric
 from deeplite.profiler.metrics import *
 
@@ -66,7 +66,7 @@ class TestProfiler(BaseUnitTest):
             return {'a': 10, 'b': 20, 'c': 30, 'd': 40}
 
         profiler = get_profiler()
-        profiler.display_status_filter_func = make_display_filter_function(exclude='c')
+        profiler.display.exclude = 'c'
         compute_eval = ComputeEvalMetric(evaluate, key='a', default_split='train')
         compute_eval.add_secondary_metric('b')
         profiler.register_profiler_function(compute_eval)


### PR DESCRIPTION
Modified Profiler to allow for registration of secondary eval metric keys *after* the EvalProfilerFunction has been registered with the profiler.

Also changed the formatter pipeline to remove the global registration of secondary eval metrics in favor of a dynamic lookup of those metrics in the profiler instance itself.

This PR is paired with a sibling PR for the engine